### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ jobs:
     name: Publish Wheel to GH Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Build Weel

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use the Action:
 
 ```yml
 - name: Make package index
-  uses: banesullivan/create-pip-index-action@main
+  uses: girder/create-pip-index-action@main
   with:
     package_directory: dist/
 ```
@@ -37,7 +37,7 @@ jobs:
           pip install wheel
           python setup.py bdist_wheel
       - name: Make package index
-        uses: banesullivan/create-pip-index-action@main
+        uses: girder/create-pip-index-action@main
         with:
           package_directory: dist/
       - name: Deploy to GH Pages


### PR DESCRIPTION
This PR fixes some minor issues I noticed when adapting the workflow example in the README to a project.

- Updates the example in the readme to point to https://github.com/girder/create-pip-index-action instead of https://github.com/banesullivan/create-pip-index-action.
- Updates some deprecated github action versions used in the workflow example.